### PR TITLE
tnvm.sh: fix egrep on MacOS

### DIFF
--- a/tnvm.sh
+++ b/tnvm.sh
@@ -518,7 +518,7 @@ _tnvm_check_params() {
   if [ "_$1" = '_system' ]; then
     return
   fi
-  echo "$1" | egrep -o '^[a-z]+-v[0-9]+\.[0-9]+\.[0-9]+[-\.a-z]+?$' > /dev/null
+  echo "$1" | egrep -o '^[a-z]+-v[0-9]+\.[0-9]+\.[0-9]+([-\.a-z]+)?$' > /dev/null
 }
 
 tnvm() {


### PR DESCRIPTION
**can't install node**
```
$ tnvm install node-v8.1.4
Version 'node-v8.1.4' not valid.
```
Tested on newly installed MacOS 10.12.5

`[-\.a-z]+?` does't match empty string
`([-\.a-z]+)?` does match empty string

```shell
 ~ echo 'node-abc' | egrep -o '[a-z]+-[a-z]+'
node-abc
~ echo 'node-' | egrep -o '[a-z]+-[a-z]+' 
~ echo 'node-' | egrep -o '[a-z]+-[a-z]+?' 
~ echo 'node-' | egrep -o '[a-z]+-([a-z]+)?'
node-
```