### PR TITLE
feat(ls-remote): list in number increase order

### DIFF
--- a/tnvm.sh
+++ b/tnvm.sh
@@ -361,10 +361,10 @@ _tnvm_ls_remote() {
   VERSIONS="$(_tnvm_download -L -s "$mirror/index.tab" -o - \
     | command sed "
         1d;
-        s/^/$PATTERN-/;
         s/[[:blank:]].*//" \
-    | command grep -w "$PATTERN" \
-    | command sort)"
+    | command sort -t . -k 1.2n -k 2n -k 3n \
+    | command sed "s/^/$PATTERN-/;" \
+  )"
 
   if [ -z "$VERSIONS" ]; then
     echo "N/A"


### PR DESCRIPTION
add sort params to list versions in a correct number increase order

remove useless `grep` step

`tnvm ls-remote node` now end with

```
   ...
   node-v9.10.0
   node-v9.10.1
   node-v9.11.0
   node-v9.11.1
   node-v9.11.2
   node-v10.0.0
   node-v10.1.0
   node-v10.2.0
   node-v10.2.1
   node-v10.3.0
   node-v10.4.0
   node-v10.4.1
   node-v10.5.0
   node-v10.6.0
   node-v10.7.0
   node-v10.8.0
   node-v10.9.0
  node-v10.10.0
  node-v10.11.0
  node-v10.12.0
  node-v10.13.0
   node-v11.0.0
   node-v11.1.0
```