### PR TITLE
src: added ARCH filter for ls-remote command.

### DIFF
--- a/tnvm.sh
+++ b/tnvm.sh
@@ -357,10 +357,11 @@ _tnvm_ls_remote() {
     "alinode") mirror=$MIRROR_ALINODE ;;
     "profiler") mirror=$MIRROR_PROFILER ;;
   esac
+  local ARCH=$(_tnvm_get_arch)
 
   VERSIONS="$(_tnvm_download -L -s "$mirror/index.tab" -o - \
+    | command grep -F "$ARCH" \
     | command sed "
-        1d;
         s/^/$PATTERN-/;
         s/[[:blank:]].*//" \
     | command grep -w "$PATTERN" \


### PR DESCRIPTION
Only the ARCH matched packages will be displayed in ls-remote command.
```
[admin@arm64 ~]$ uname -a
Linux arm64 4.18.0-147.8.1.el7.aarch64 #1 SMP Wed Apr 15 18:13:44 UTC 2020 aarch64 aarch64 aarch64 GNU/Linux
[admin@arm64 ~]$ tnvm ls-remote alinode
alinode-v5.16.0
[admin@arm64 ~]$
```