### PR TITLE
feat: support install node on darwin x64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 versions
 bin
+.tnvmrc


### PR DESCRIPTION
`tnvm` 当前版本会根据 arch 拼接 runtime tar 包，而在 darwin 下，上游从 node-v16.x 才开始提供 darwin arm64 的编译版本会导致安装失败。

因此在 < v16.x 时可以将 arch 置为 `x64` 来下载对应的 `x64` 版本（rosetta 可以自动转译指令在 darwin arm64 上使用），这样可以使得 `tnvm` 适配 darwin arm64 环境下的使用，并且 >=16.x 的版本可以继续安装 arm64 的原生版本